### PR TITLE
Make jquery.organictabs AMD-compatible

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,2 @@
+---
+  extends: "eslint:recommended"

--- a/js/jquery.organictabs.js
+++ b/js/jquery.organictabs.js
@@ -1,4 +1,15 @@
-(function($) {
+/*jshint browser:true */
+/*global define, jQuery */
+
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(['jquery'], factory);
+	} else {
+		// Browser globals
+		factory(jQuery);
+	}
+}(function ($) {
 
     $.organicTabs = function(el, options) {
     
@@ -121,4 +132,4 @@
         });
     };
 
-})(jQuery);
+}));

--- a/js/jquery.organictabs.js
+++ b/js/jquery.organictabs.js
@@ -1,5 +1,5 @@
 /*jshint browser:true */
-/*global define, jQuery */
+/*global define, jQuery, window */
 
 (function (factory) {
     if (typeof define === 'function' && define.amd) {

--- a/js/jquery.organictabs.js
+++ b/js/jquery.organictabs.js
@@ -81,17 +81,17 @@
         base.init();
 
         // check for window.state, if exists then activate
-        if(history.state && history.state.length !==0){
-            if("organictabsState" in history.state){ // check for the organictabsState key
                 
+        if(window.history.state && window.history.state.length !==0){
+            if("organictabsState" in window.history.state){ // check for the organictabsState key
                 // pull back in all of the var declarations so that they're accessible at start
                 curList = base.$el.find("a.current").attr("href").substring(1);
-                stateID = history.state.organictabsState;
+                stateID = window.history.state.organictabsState;
                 $allListWrap = base.$el.find(".list-wrap"),
                 curListHeight = $allListWrap.height();
                 $allListWrap.height(curListHeight);
 
-                if (history.state.organictabsState != curList) {
+                if (window.history.state.organictabsState != curList) {
 
                                             
                     // Fade out current list

--- a/js/jquery.organictabs.js
+++ b/js/jquery.organictabs.js
@@ -2,13 +2,13 @@
 /*global define, jQuery */
 
 (function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// AMD. Register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// Browser globals
-		factory(jQuery);
-	}
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
 }(function ($) {
 
     $.organicTabs = function(el, options) {


### PR DESCRIPTION
- I've changed the boilerplate to make the plugin work with AMD loaders such as require.js, but using the Universal Module Definition pattern from https://github.com/umdjs/umd such that it will continue to work when loaded in the traditional non-AMD (script src) way.
